### PR TITLE
correct .env.example comment on backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 WLD_CLIENT_ID=
 WLD_CLIENT_SECRET=
-# needed by authjs, use `openssl rand -base64 32 to generate`
+# needed by authjs, use `openssl rand -base64 32` to generate
 AUTH_SECRET=


### PR DESCRIPTION
This pull request includes a minor change to the `backend/.env.example` file. The change corrects a comment to clarify the command syntax for generating a secret.

* [`backend/.env.example`](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080L3-R3): Corrected the comment to properly format the command for generating a secret.